### PR TITLE
Update apiKey in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/plugin install logstash-output-opsgenie
 ```sh
 output {
 	opsgenie {
-		"apiKey" => "logstash_integration_api_key"
+		apiKey => "logstash_integration_api_key"
 	}
 }
 ```


### PR DESCRIPTION
The previous version showed the output section with apiKey quoted. The correct logstash configuration requires apiKey to not be quoted.